### PR TITLE
add minimum wasm changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "examples/read_parquet",
   "examples/python_rust_compiled_function",
 ]
+version = "0.24.3"
 
 [workspace.package]
 version = "0.24.3"

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -282,6 +282,10 @@ polars-lazy = { version = "0.24.3", path = "./polars-lazy", features = ["private
 polars-ops = { version = "0.24.3", path = "./polars-ops" }
 polars-time = { version = "0.24.3", path = "./polars-time", default-features = false, optional = true }
 
+# enable js feature for getrandom to work in wasm
+[target.'cfg(target_family = "wasm")'.dependencies.getrandom]
+features = ["js"]
+
 [dev-dependencies]
 ahash = "0.7"
 criterion = "0.3"

--- a/polars/polars-arrow/Cargo.toml
+++ b/polars/polars-arrow/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-arrow"
 version.workspace = true

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-core"
 version.workspace = true

--- a/polars/polars-core/src/frame/groupby/proxy.rs
+++ b/polars/polars-core/src/frame/groupby/proxy.rs
@@ -26,11 +26,14 @@ impl Drop for GroupsIdx {
         let v = std::mem::take(&mut self.all);
         // ~65k took approximately 1ms on local machine, so from that point we drop on other thread
         // to stop query from being blocked
+        #[cfg(not(target_family = "wasm"))]
         if v.len() > 1 << 16 {
             std::thread::spawn(move || drop(v));
         } else {
             drop(v);
         }
+        #[cfg(target_family = "wasm")]
+        drop(v);
     }
 }
 

--- a/polars/polars-core/src/lib.rs
+++ b/polars/polars-core/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) static PROCESS_ID: Lazy<u128> = Lazy::new(|| {
 });
 
 // this is re-exported in utils for polars child crates
+#[cfg(not(target_family = "wasm"))] // only use this on non wasm targets
 pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
     ThreadPoolBuilder::new()
         .num_threads(
@@ -58,6 +59,9 @@ pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
         .build()
         .expect("could not spawn threads")
 });
+
+#[cfg(target_family = "wasm")] // instead use this on wasm targets
+pub static POOL: Lazy<polars_utils::wasm::Pool> = Lazy::new(|| polars_utils::wasm::Pool);
 
 // utility for the tests to ensure a single thread can execute
 pub static SINGLE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-io"
 version.workspace = true

--- a/polars/polars-io/src/csv/read_impl.rs
+++ b/polars/polars-io/src/csv/read_impl.rs
@@ -498,7 +498,9 @@ impl<'a> CoreReader<'a> {
 
         // If the number of threads given by the user is lower than our global thread pool we create
         // new one.
+        #[cfg(not(target_family = "wasm"))]
         let owned_pool;
+        #[cfg(not(target_family = "wasm"))]
         let pool = if POOL.current_num_threads() != n_threads {
             owned_pool = Some(
                 ThreadPoolBuilder::new()
@@ -510,6 +512,9 @@ impl<'a> CoreReader<'a> {
         } else {
             &POOL
         };
+
+        #[cfg(target_family = "wasm")] // use a pre-created pool for wasm
+        let pool = &POOL;
 
         // An empty file with a schema should return an empty DataFrame with that schema
         if bytes.is_empty() {

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-lazy"
 version.workspace = true

--- a/polars/polars-lazy/polars-plan/Cargo.toml
+++ b/polars/polars-lazy/polars-plan/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-plan"
 version.workspace = true

--- a/polars/polars-ops/Cargo.toml
+++ b/polars/polars-ops/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-ops"
 version.workspace = true

--- a/polars/polars-time/Cargo.toml
+++ b/polars/polars-time/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-time"
 version.workspace = true

--- a/polars/polars-utils/Cargo.toml
+++ b/polars/polars-utils/Cargo.toml
@@ -1,3 +1,4 @@
+cargo-features = ["workspace-inheritance"]
 [package]
 name = "polars-utils"
 version.workspace = true

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -12,3 +12,6 @@ pub use functions::*;
 pub type IdxSize = u32;
 #[cfg(feature = "bigidx")]
 pub type IdxSize = u64;
+
+#[cfg(target_family = "wasm")]
+pub mod wasm;

--- a/polars/polars-utils/src/sort.rs
+++ b/polars/polars-utils/src/sort.rs
@@ -16,6 +16,7 @@ use crate::IdxSize;
 ///
 /// # Safety
 /// The caller must ensure that the right indexes fo `&[(_, IdxSize)]` are integers ranging from `0..idx.len`
+#[cfg(not(target_family = "wasm"))]
 pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)], out: &mut Vec<IdxSize>) {
     let chunk_size = std::cmp::max(
         idx.len() / pool.current_num_threads(),
@@ -39,4 +40,41 @@ pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)], out: &
     // Safety:
     // all elements are written
     out.set_len(idx.len());
+}
+
+macro_rules! perfect_sort_inner {
+    ($pool:expr, $idx:expr, $idz:expr) => {{
+        let chunk_size = std::cmp::max(
+            $idx.len() / $pool.current_num_threads(),
+            $pool.current_num_threads(),
+        );
+
+        let mut out: Vec<IdxSize> = Vec::with_capacity($idx.len());
+        let ptr = out.as_mut_ptr() as *const IdxSize as usize;
+
+        $pool.install(|| {
+            $idx.par_chunks(chunk_size).for_each(|indices| {
+                let ptr = ptr as *mut IdxSize;
+                for (idx_val, idx_location) in indices {
+                    // Safety:
+                    // idx_location is in bounds by invariant of this function
+                    // and we ensured we have at least `idx.len()` capacity
+                    *ptr.add(*idx_location as usize) = *idx_val;
+                }
+            });
+        });
+        // Safety:
+        // all elements are written
+        out.set_len($idx.len());
+        out
+    }};
+}
+
+#[cfg(target_family = "wasm")]
+pub unsafe fn perfect_sort(
+    pool: &crate::wasm::Pool,
+    idx: &[(IdxSize, IdxSize)],
+    out: &mut Vec<IdxSize>,
+) -> Vec<IdxSize> {
+    perfect_sort_inner!(pool, idx, out)
 }

--- a/polars/polars-utils/src/wasm.rs
+++ b/polars/polars-utils/src/wasm.rs
@@ -1,0 +1,32 @@
+pub struct Pool;
+
+impl Pool {
+    pub fn current_num_threads(&self) -> usize {
+        rayon::current_num_threads()
+    }
+
+    pub fn install<OP, R>(&self, op: OP) -> R
+    where
+        OP: FnOnce() -> R + Send,
+        R: Send,
+    {
+        op()
+    }
+
+    pub fn join<A, B, RA, RB>(&self, oper_a: A, oper_b: B) -> (RA, RB)
+    where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send,
+    {
+        rayon::join(oper_a, oper_b)
+    }
+
+    pub fn spawn<F>(&self, func: F)
+    where
+        F: 'static + FnOnce() + Send,
+    {
+        rayon::spawn(func);
+    }
+}


### PR DESCRIPTION
This is the minimum changes required to have polars working in wasm.
Had to add `cargo-features = ["workspace-inheritance"]` to each crate to enable the workspace inheritance feature for rust versions < 1.64